### PR TITLE
Allow volume louder than 100% using keyboard or mouse scroll

### DIFF
--- a/panel-plugin/pulseaudio-button.c
+++ b/panel-plugin/pulseaudio-button.c
@@ -235,7 +235,12 @@ pulseaudio_button_scroll_event (GtkWidget *widget, GdkEventScroll *event)
   if (event->direction == 1)  // decrease volume
     new_volume = volume - volume_step;
   else if (event->direction == 0)  // increase volume
-    new_volume = MIN (volume + volume_step, MAX (volume, 1.0));
+  {
+    if (!pulseaudio_config_get_allow_louder_than_hundred (button->config))
+      new_volume = MIN (volume + volume_step, MAX (volume, 1.0));
+    else
+      new_volume = volume + volume_step;
+  }
   else
     new_volume = volume;
 

--- a/panel-plugin/pulseaudio-config.c
+++ b/panel-plugin/pulseaudio-config.c
@@ -246,7 +246,7 @@ pulseaudio_config_init (PulseaudioConfig *config)
   config->enable_keyboard_shortcuts = DEFAULT_ENABLE_KEYBOARD_SHORTCUTS;
   config->enable_multimedia_keys    = DEFAULT_ENABLE_MULTIMEDIA_KEYS;
   config->show_notifications        = DEFAULT_SHOW_NOTIFICATIONS;
-  config->allow_louder_than_hundred       = DEFAULT_ALLOW_LOUDER_THAN_HUNDRED;
+  config->allow_louder_than_hundred = DEFAULT_ALLOW_LOUDER_THAN_HUNDRED;
   config->volume_step               = DEFAULT_VOLUME_STEP;
   config->volume_max                = DEFAULT_VOLUME_MAX;
   config->mixer_command             = g_strdup (DEFAULT_MIXER_COMMAND);

--- a/panel-plugin/pulseaudio-config.c
+++ b/panel-plugin/pulseaudio-config.c
@@ -670,6 +670,10 @@ pulseaudio_config_new (const gchar     *property_base)
       xfconf_g_property_bind (channel, property, G_TYPE_BOOLEAN, config, "show-notifications");
       g_free (property);
 
+      property = g_strconcat (property_base, "/allow-louder-than-hundred", NULL);
+      xfconf_g_property_bind (channel, property, G_TYPE_BOOLEAN, config, "allow-louder-than-hundred");
+      g_free (property);
+
       property = g_strconcat (property_base, "/volume-step", NULL);
       xfconf_g_property_bind (channel, property, G_TYPE_UINT, config, "volume-step");
       g_free (property);

--- a/panel-plugin/pulseaudio-config.c
+++ b/panel-plugin/pulseaudio-config.c
@@ -45,6 +45,7 @@
 
 #define DEFAULT_ENABLE_KEYBOARD_SHORTCUTS         TRUE
 #define DEFAULT_SHOW_NOTIFICATIONS                TRUE
+#define DEFAULT_ALLOW_LOUDER_THAN_HUNDRED         FALSE
 #define DEFAULT_VOLUME_STEP                       5
 #define DEFAULT_VOLUME_MAX                        150
 
@@ -85,6 +86,7 @@ struct _PulseaudioConfig
   gboolean         enable_keyboard_shortcuts;
   gboolean         enable_multimedia_keys;
   gboolean         show_notifications;
+  gboolean         allow_louder_than_hundred;
   guint            volume_step;
   guint            volume_max;
   gchar           *mixer_command;
@@ -101,6 +103,7 @@ enum
     PROP_ENABLE_KEYBOARD_SHORTCUTS,
     PROP_ENABLE_MULTIMEDIA_KEYS,
     PROP_SHOW_NOTIFICATIONS,
+    PROP_ALLOW_LOUDER_THAN_HUNDRED,
     PROP_VOLUME_STEP,
     PROP_VOLUME_MAX,
     PROP_MIXER_COMMAND,
@@ -158,6 +161,15 @@ pulseaudio_config_class_init (PulseaudioConfigClass *klass)
                                                          DEFAULT_SHOW_NOTIFICATIONS,
                                                          G_PARAM_READWRITE |
                                                          G_PARAM_STATIC_STRINGS));
+
+
+
+ g_object_class_install_property (gobject_class,
+                                  PROP_ALLOW_LOUDER_THAN_HUNDRED,
+                                  g_param_spec_boolean ("allow-louder-than-hundred", NULL, NULL,
+                                                        DEFAULT_ALLOW_LOUDER_THAN_HUNDRED,
+                                                        G_PARAM_READWRITE |
+                                                        G_PARAM_STATIC_STRINGS));
 
 
 
@@ -234,6 +246,7 @@ pulseaudio_config_init (PulseaudioConfig *config)
   config->enable_keyboard_shortcuts = DEFAULT_ENABLE_KEYBOARD_SHORTCUTS;
   config->enable_multimedia_keys    = DEFAULT_ENABLE_MULTIMEDIA_KEYS;
   config->show_notifications        = DEFAULT_SHOW_NOTIFICATIONS;
+  config->allow_louder_than_hundred       = DEFAULT_ALLOW_LOUDER_THAN_HUNDRED;
   config->volume_step               = DEFAULT_VOLUME_STEP;
   config->volume_max                = DEFAULT_VOLUME_MAX;
   config->mixer_command             = g_strdup (DEFAULT_MIXER_COMMAND);
@@ -277,6 +290,10 @@ pulseaudio_config_get_property (GObject    *object,
 
     case PROP_SHOW_NOTIFICATIONS:
       g_value_set_boolean (value, config->show_notifications);
+      break;
+
+    case PROP_ALLOW_LOUDER_THAN_HUNDRED:
+      g_value_set_boolean (value, config->allow_louder_than_hundred);
       break;
 
     case PROP_VOLUME_STEP:
@@ -349,6 +366,16 @@ pulseaudio_config_set_property (GObject      *object,
         {
           config->show_notifications = val_bool;
           g_object_notify (G_OBJECT (config), "show-notifications");
+          g_signal_emit (G_OBJECT (config), pulseaudio_config_signals [CONFIGURATION_CHANGED], 0);
+        }
+      break;
+
+    case PROP_ALLOW_LOUDER_THAN_HUNDRED:
+      val_bool = g_value_get_boolean (value);
+      if (config->allow_louder_than_hundred != val_bool)
+        {
+          config->allow_louder_than_hundred = val_bool;
+          g_object_notify (G_OBJECT (config), "allow-louder-than-hundred");
           g_signal_emit (G_OBJECT (config), pulseaudio_config_signals [CONFIGURATION_CHANGED], 0);
         }
       break;
@@ -451,6 +478,15 @@ pulseaudio_config_get_show_notifications (PulseaudioConfig *config)
   return config->show_notifications;
 }
 
+
+
+gboolean
+pulseaudio_config_get_allow_louder_than_hundred (PulseaudioConfig *config)
+{
+  g_return_val_if_fail (IS_PULSEAUDIO_CONFIG (config), DEFAULT_ALLOW_LOUDER_THAN_HUNDRED);
+
+  return config->allow_louder_than_hundred;
+}
 
 
 guint

--- a/panel-plugin/pulseaudio-config.h
+++ b/panel-plugin/pulseaudio-config.h
@@ -41,6 +41,7 @@ PulseaudioConfig  *pulseaudio_config_new                            (const gchar
 gboolean           pulseaudio_config_get_enable_keyboard_shortcuts  (PulseaudioConfig     *config);
 gboolean           pulseaudio_config_get_enable_multimedia_keys     (PulseaudioConfig     *config);
 gboolean           pulseaudio_config_get_show_notifications         (PulseaudioConfig     *config);
+gboolean           pulseaudio_config_get_allow_louder_than_hundred        (PulseaudioConfig     *config);
 guint              pulseaudio_config_get_volume_step                (PulseaudioConfig     *config);
 guint              pulseaudio_config_get_volume_max                 (PulseaudioConfig     *config);
 const gchar       *pulseaudio_config_get_mixer_command              (PulseaudioConfig     *config);

--- a/panel-plugin/pulseaudio-config.h
+++ b/panel-plugin/pulseaudio-config.h
@@ -41,7 +41,7 @@ PulseaudioConfig  *pulseaudio_config_new                            (const gchar
 gboolean           pulseaudio_config_get_enable_keyboard_shortcuts  (PulseaudioConfig     *config);
 gboolean           pulseaudio_config_get_enable_multimedia_keys     (PulseaudioConfig     *config);
 gboolean           pulseaudio_config_get_show_notifications         (PulseaudioConfig     *config);
-gboolean           pulseaudio_config_get_allow_louder_than_hundred        (PulseaudioConfig     *config);
+gboolean           pulseaudio_config_get_allow_louder_than_hundred  (PulseaudioConfig     *config);
 guint              pulseaudio_config_get_volume_step                (PulseaudioConfig     *config);
 guint              pulseaudio_config_get_volume_max                 (PulseaudioConfig     *config);
 const gchar       *pulseaudio_config_get_mixer_command              (PulseaudioConfig     *config);

--- a/panel-plugin/pulseaudio-dialog.c
+++ b/panel-plugin/pulseaudio-dialog.c
@@ -188,8 +188,6 @@ pulseaudio_dialog_build (PulseaudioDialog *dialog)
 
       object = gtk_builder_get_object (builder, "checkbutton-show-notifications");
       g_return_if_fail (GTK_IS_CHECK_BUTTON (object));
-      // object = gtk_builder_get_object (builder, "checkbutton-allow-louder-than-hundred");
-      // g_return_if_fail (GTK_IS_CHECK_BUTTON (object));
 #ifdef HAVE_LIBNOTIFY
       g_object_bind_property (G_OBJECT (dialog->config), "show-notifications",
                               G_OBJECT (object), "active",

--- a/panel-plugin/pulseaudio-dialog.c
+++ b/panel-plugin/pulseaudio-dialog.c
@@ -180,8 +180,16 @@ pulseaudio_dialog_build (PulseaudioDialog *dialog)
                               G_OBJECT (object), "active",
                               G_BINDING_SYNC_CREATE | G_BINDING_BIDIRECTIONAL);
 
+      object = gtk_builder_get_object (builder, "checkbutton-allow-louder-than-hundred");
+      g_return_if_fail (GTK_IS_CHECK_BUTTON (object));
+      g_object_bind_property (G_OBJECT (dialog->config), "allow-louder-than-hundred",
+                              G_OBJECT (object), "active",
+                              G_BINDING_SYNC_CREATE | G_BINDING_BIDIRECTIONAL);
+
       object = gtk_builder_get_object (builder, "checkbutton-show-notifications");
       g_return_if_fail (GTK_IS_CHECK_BUTTON (object));
+      // object = gtk_builder_get_object (builder, "checkbutton-allow-louder-than-hundred");
+      // g_return_if_fail (GTK_IS_CHECK_BUTTON (object));
 #ifdef HAVE_LIBNOTIFY
       g_object_bind_property (G_OBJECT (dialog->config), "show-notifications",
                               G_OBJECT (object), "active",

--- a/panel-plugin/pulseaudio-dialog.glade
+++ b/panel-plugin/pulseaudio-dialog.glade
@@ -123,6 +123,22 @@
                             <property name="position">1</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="checkbutton-allow-louder-than-hundred">
+                            <property name="label" translatable="yes">Allow louder than 100%</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="use_underline">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/panel-plugin/pulseaudio-notify.c
+++ b/panel-plugin/pulseaudio-notify.c
@@ -170,6 +170,7 @@ pulseaudio_notify_notify (PulseaudioNotify *notify, gboolean mic)
   GError             *error = NULL;
   NotifyNotification *notification;
   gdouble             volume;
+  gdouble             volume_max;
   gint                volume_i;
   gboolean            muted;
   gboolean            connected;
@@ -190,7 +191,12 @@ pulseaudio_notify_notify (PulseaudioNotify *notify, gboolean mic)
   volume = (mic ? pulseaudio_volume_get_volume_mic : pulseaudio_volume_get_volume) (notify->volume);
   muted = (mic ? pulseaudio_volume_get_muted_mic : pulseaudio_volume_get_muted) (notify->volume);
   connected = pulseaudio_volume_get_connected (notify->volume);
-  volume_i = (gint) round (volume * 100);
+  volume_max = pulseaudio_config_get_volume_max(notify->config) / 100.0;
+
+  if (!pulseaudio_config_get_allow_louder_than_hundred (notify->config))
+    volume_i = (gint) round (volume * 100);
+  else
+    volume_i = (gint) round (volume * 100 / volume_max);
 
   if (!connected)
     volume_i = 0;

--- a/panel-plugin/pulseaudio-plugin.c
+++ b/panel-plugin/pulseaudio-plugin.c
@@ -351,7 +351,12 @@ pulseaudio_plugin_volume_key_pressed (const char            *keystring,
   pulseaudio_debug ("%s pressed", keystring);
 
   if (strcmp (keystring, PULSEAUDIO_PLUGIN_RAISE_VOLUME_KEY) == 0)
-    pulseaudio_volume_set_volume (pulseaudio_plugin->volume, MIN (volume + volume_step, MAX (volume, 1.0)));
+  {
+    if (!pulseaudio_config_get_allow_louder_than_hundred (pulseaudio_plugin->config))
+      pulseaudio_volume_set_volume (pulseaudio_plugin->volume, MIN (volume + volume_step, MAX (volume, 1.0)));
+    else
+      pulseaudio_volume_set_volume (pulseaudio_plugin->volume, volume + volume_step);
+  }
   else if (strcmp (keystring, PULSEAUDIO_PLUGIN_LOWER_VOLUME_KEY) == 0)
     pulseaudio_volume_set_volume (pulseaudio_plugin->volume, volume - volume_step);
 }


### PR DESCRIPTION
Hello! Since sometimes it is not very convenient to increase the volume above 100% using only the slider, I tried to make some changes: 1) Volume can be increased above 100% with keyboard and scrolling. 2) Added a checkbox in GUI to enable/disable this feature manually. 3) Also added scaling volume bar in notifications depending on the state of the checkbox.
 
There is such a feature in Unity and KDE Plasma 5:
![](https://i.stack.imgur.com/IFrKP.png)

![](https://i.stack.imgur.com/WLfuF.png)

  #
  